### PR TITLE
Setup Hashicorp Vault and Vault-based credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Mock accounts will be configured automatically and can be used to login. For the
 | jane     | User        |
 | john     | User        |
 
-> **_NOTE:_**  Jobs are configured to run as the "auto" user by default. Because of this, you must login to the "auto" user once for jobs to work as intended. This is because the "auto" user does not yet exist on first boot, and so jobs are running as "anonmyous" which does not have any permissions. The "auto" user is created after first time login.
+> **_NOTE:_** Jobs are configured to run as the "auto" user by default. Because of this, you must login to the "auto" user once for jobs to work as intended. This is because the "auto" user does not yet exist on first boot, and so jobs are running as "anonmyous" which does not have any permissions. The "auto" user is created after first time login.
 
 ## With Hashicorp Vault
 If you want to run this Jenkins instance with the configured Hashicorp Vault credentials, set the following environment variables before running the `Install-Jenkins.ps1` script:
@@ -28,3 +28,5 @@ If you want to run this Jenkins instance with the configured Hashicorp Vault cre
 - `CASC_VAULT_APPROLE`: Vault AppRole ID
 - `CASC_VAULT_APPROLE_SECRET`: Vault AppRole Secret ID
 - `CASC_VAULT_ENGINE_VERSION`: Vault kv secret engine version "1" or "2"
+
+> **_NOTE:_** Because this Jenkins setup is configured to use Hashicorp Vault for credentials, all non-Vault Jenkins credentials types have been disabled.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Jenkins Test
-
 This is used for testing Jenkins Configuration as Code (JCasC), Jenkins Pipeline as Code, Jenkins Plugin Installation Manager Tool, and Jenkins Job DSL functionality.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Mock accounts will be configured automatically and can be used to login. For the
 | john     | User        |
 
 > **_NOTE:_**  Jobs are configured to run as the "auto" user by default. Because of this, you must login to the "auto" user once for jobs to work as intended. This is because the "auto" user does not yet exist on first boot, and so jobs are running as "anonmyous" which does not have any permissions. The "auto" user is created after first time login.
+
+## With Hashicorp Vault
+If you want to run this Jenkins instance with the configured Hashicorp Vault credentials, set the following environment variables before running the `Install-Jenkins.ps1` script:
+
+- `CASC_VAULT_URL`: Vault server URL
+- `CASC_VAULT_APPROLE`: Vault AppRole ID
+- `CASC_VAULT_APPROLE_SECRET`: Vault AppRole Secret ID
+- `CASC_VAULT_ENGINE_VERSION`: Vault kv secret engine version "1" or "2"

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,5 +1,4 @@
 # Jenkins Configuration Code
-
 This directory contains config files that are used to configure Jenkins entirely through code.
 
 The `casc/` folder holds Jenkins Configuration as Code files (JCasC) split based on the Jenkins UI categories. These are the files that Jenkins is setup to use for configuration.

--- a/configs/casc/credentials.yaml
+++ b/configs/casc/credentials.yaml
@@ -1,4 +1,24 @@
 # Manage Jenkins >> Credentials
+credentials:
+
+  system:
+    domainCredentials:
+    - credentials:
+      - vaultAppRoleCredential:
+          id: "vault-jenkins-role"
+          path: "approle"
+          roleId: "${CASC_VAULT_APPROLE}"
+          scope: GLOBAL
+          secretId: "${CASC_VAULT_APPROLE_SECRET}"
+          usePolicies: false
+
+      - vaultStringCredentialImpl:
+          engineVersion: "${CASC_VAULT_ENGINE_VERSION}"
+          id: "vault-secret-text"
+          path: "secrets/creds/secret-text"
+          scope: GLOBAL
+          vaultKey: "secret"
+
 globalCredentialsConfiguration:
 
   configuration:

--- a/configs/casc/credentials.yaml
+++ b/configs/casc/credentials.yaml
@@ -20,7 +20,28 @@ credentials:
           vaultKey: "secret"
 
 globalCredentialsConfiguration:
-
   configuration:
-    providerFilter: "none"
-    typeFilter: "none"
+
+    providerFilter:
+      includes:
+        classNames:
+        - "com.datapipe.jenkins.vault.credentials.VaultCredentialsProvider"
+        - "com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider"
+        - "com.cloudbees.plugins.credentials.SystemCredentialsProvider$ProviderImpl"
+
+    typeFilter:
+      includes:
+        classNames:
+        - "com.datapipe.jenkins.vault.credentials.VaultAwsIamCredential"
+        - "com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultCertificateCredentialsImpl"
+        - "com.datapipe.jenkins.vault.credentials.VaultGCPCredential"
+        - "com.datapipe.jenkins.vault.credentials.VaultGithubTokenCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultGCRLoginImpl"
+        - "com.datapipe.jenkins.vault.credentials.VaultKubernetesCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultSSHUserPrivateKeyImpl"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultFileCredentialImpl"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultStringCredentialImpl"
+        - "com.datapipe.jenkins.vault.credentials.VaultTokenCredential"
+        - "com.datapipe.jenkins.vault.credentials.VaultTokenFileCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultUsernamePasswordCredentialImpl"

--- a/configs/casc/jobs.yaml
+++ b/configs/casc/jobs.yaml
@@ -7,6 +7,7 @@ jobs:
   - url: https://raw.githubusercontent.com/Minreaux/jenkins-test/setup-hashicorp-vault/jenkinsfiles/seedJobs.groovy
   
   # Disables the seedJobs pipeline initially because it does not work on first time boot; requires automation user setup first
+  # script code is Groovy, not YAML
   - script: >
       multibranchPipelineJob('seedJobs')
       {

--- a/configs/casc/jobs.yaml
+++ b/configs/casc/jobs.yaml
@@ -3,5 +3,15 @@
 jobs:
   - providedEnv:
       # Provides initial BRANCH_NAME used for initial seedJobs pipeline setup
-      BRANCH_NAME: 'main'
-  - url: https://raw.githubusercontent.com/Minreaux/jenkins-test/main/jenkinsfiles/seedJobs.groovy
+      BRANCH_NAME: 'setup-hashicorp-vault'
+  - url: https://raw.githubusercontent.com/Minreaux/jenkins-test/setup-hashicorp-vault/jenkinsfiles/seedJobs.groovy
+  
+  # Disables the seedJobs pipeline initially because it does not work on first time boot; requires automation user setup first
+  - script: >
+      multibranchPipelineJob('seedJobs')
+      {
+          configure
+          {
+              it / disabled << 'true'
+          }
+      }

--- a/configs/casc/security.yaml
+++ b/configs/casc/security.yaml
@@ -46,6 +46,7 @@ jenkins:
           pattern: ".*"
           permissions:
           - "Agent/Build"
+          - "Job/Configure"
           - "Job/Create"
           - "Job/Delete"
           - "Job/Discover"

--- a/configs/casc/system.yaml
+++ b/configs/casc/system.yaml
@@ -51,6 +51,15 @@ unclassified:
                     sparseCheckoutPaths:
                     - path: "shared_libraries/utils/"
 
+  hashicorpVault:
+    configuration:
+      disableChildPoliciesOverride: false
+      engineVersion: "${CASC_VAULT_ENGINE_VERSION}"
+      skipSslVerification: true
+      timeout: 60
+      vaultCredentialId: "vault-jenkins-role"
+      vaultUrl: "${CASC_VAULT_URL}"
+
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"
     url: "http://localhost:8080/"

--- a/configs/jenkins.yaml
+++ b/configs/jenkins.yaml
@@ -1,3 +1,20 @@
+credentials:
+  system:
+    domainCredentials:
+    - credentials:
+      - vaultAppRoleCredential:
+          id: "vault-jenkins-role"
+          path: "approle"
+          roleId: "${CASC_VAULT_APPROLE}"
+          scope: GLOBAL
+          secretId: "${CASC_VAULT_APPROLE_SECRET}"
+          usePolicies: false
+      - vaultStringCredentialImpl:
+          engineVersion: "${CASC_VAULT_ENGINE_VERSION}"
+          id: "vault-secret-text"
+          path: "secrets/creds/secret-text"
+          scope: GLOBAL
+          vaultKey: "secret"
 jenkins:
   agentProtocols:
   - "JNLP4-connect"
@@ -174,6 +191,14 @@ unclassified:
                   extension:
                     sparseCheckoutPaths:
                     - path: "shared_libraries/utils/"
+  hashicorpVault:
+    configuration:
+      disableChildPoliciesOverride: false
+      engineVersion: "${CASC_VAULT_ENGINE_VERSION}"
+      skipSslVerification: true
+      timeout: 60
+      vaultCredentialId: "${CASC_VAULT_URL}"
+      vaultUrl: "${CASC_VAULT_URL}"
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"
     url: "http://localhost:8080/"

--- a/configs/jenkins.yaml
+++ b/configs/jenkins.yaml
@@ -46,6 +46,7 @@ jenkins:
           - "Job/Discover"
           - "Job/Read"
           - "Agent/Build"
+          - "Job/Configure"
         - entries:
           - group: "authenticated"
           name: "User"

--- a/configs/jenkins.yaml
+++ b/configs/jenkins.yaml
@@ -197,7 +197,7 @@ unclassified:
       engineVersion: "${CASC_VAULT_ENGINE_VERSION}"
       skipSslVerification: true
       timeout: 60
-      vaultCredentialId: "${CASC_VAULT_URL}"
+      vaultCredentialId: "vault-jenkins-role"
       vaultUrl: "${CASC_VAULT_URL}"
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"

--- a/configs/jenkins.yaml
+++ b/configs/jenkins.yaml
@@ -140,8 +140,28 @@ jenkins:
   viewsTabBar: "standard"
 globalCredentialsConfiguration:
   configuration:
-    providerFilter: "none"
-    typeFilter: "none"
+    providerFilter:
+      includes:
+        classNames:
+        - "com.datapipe.jenkins.vault.credentials.VaultCredentialsProvider"
+        - "com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider"
+        - "com.cloudbees.plugins.credentials.SystemCredentialsProvider$ProviderImpl"
+    typeFilter:
+      includes:
+        classNames:
+        - "com.datapipe.jenkins.vault.credentials.VaultAwsIamCredential"
+        - "com.datapipe.jenkins.vault.credentials.VaultAppRoleCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultCertificateCredentialsImpl"
+        - "com.datapipe.jenkins.vault.credentials.VaultGCPCredential"
+        - "com.datapipe.jenkins.vault.credentials.VaultGithubTokenCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultGCRLoginImpl"
+        - "com.datapipe.jenkins.vault.credentials.VaultKubernetesCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultSSHUserPrivateKeyImpl"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultFileCredentialImpl"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultStringCredentialImpl"
+        - "com.datapipe.jenkins.vault.credentials.VaultTokenCredential"
+        - "com.datapipe.jenkins.vault.credentials.VaultTokenFileCredential"
+        - "com.datapipe.jenkins.vault.credentials.common.VaultUsernamePasswordCredentialImpl"
 appearance:
   pipelineGraphView:
     showGraphOnBuildPage: true

--- a/configs/plugins.yaml
+++ b/configs/plugins.yaml
@@ -16,6 +16,9 @@ plugins:
   - artifactId: git
     source:
       version: latest
+  - artifactId: hashicorp-vault-plugin
+    source:
+      version: latest
   - artifactId: job-dsl
     source:
       version: latest

--- a/jenkinsfiles/README.md
+++ b/jenkinsfiles/README.md
@@ -1,4 +1,4 @@
 # Jenkins Job-DSL and Pipeline Code
 This directory contains Jenkins Job-DSL scripts and Jenkinsfile pipelines that are used to configure Jenkins jobs (AKA Projects) entirely through code.
 
-To access the Job-DSL API that shows only those things configured for this Jenkins instance, you can go to http://localhost:8080/plugin/job-dsl/api-viewer/index.html
+To access the Job-DSL API, you can go to http://localhost:8080/plugin/job-dsl/api-viewer/index.html. This API viewer shows only the components available for this Jenkins instance.

--- a/jenkinsfiles/README.md
+++ b/jenkinsfiles/README.md
@@ -1,0 +1,4 @@
+# Jenkins Job-DSL Code
+This directory contains Jenkins Job-DSL scripts and Jenkinsfile pipelines that are used to configure Jenkins jobs (AKA Projects) entirely through code.
+
+To access the Job-DSL API that shows only those things configured for this Jenkins instance, you can go to http://localhost:8080/plugin/job-dsl/api-viewer/index.html

--- a/jenkinsfiles/README.md
+++ b/jenkinsfiles/README.md
@@ -1,4 +1,4 @@
-# Jenkins Job-DS and Pipeline Code
+# Jenkins Job-DSL and Pipeline Code
 This directory contains Jenkins Job-DSL scripts and Jenkinsfile pipelines that are used to configure Jenkins jobs (AKA Projects) entirely through code.
 
 To access the Job-DSL API that shows only those things configured for this Jenkins instance, you can go to http://localhost:8080/plugin/job-dsl/api-viewer/index.html

--- a/jenkinsfiles/README.md
+++ b/jenkinsfiles/README.md
@@ -1,4 +1,4 @@
-# Jenkins Job-DSL Code
+# Jenkins Job-DS and Pipeline Code
 This directory contains Jenkins Job-DSL scripts and Jenkinsfile pipelines that are used to configure Jenkins jobs (AKA Projects) entirely through code.
 
 To access the Job-DSL API that shows only those things configured for this Jenkins instance, you can go to http://localhost:8080/plugin/job-dsl/api-viewer/index.html

--- a/jenkinsfiles/helloWorld.groovy
+++ b/jenkinsfiles/helloWorld.groovy
@@ -1,4 +1,4 @@
-// Job DSL Groovy script that defines the job configuration for the helloWorld Jenkins pipeline
+// Job DSL Groovy script that defines the job configuration for the helloWorld Jenkins multibranch pipeline
 multibranchPipelineJob('helloWorld')
 {
     branchSources

--- a/jenkinsfiles/seedJobs.groovy
+++ b/jenkinsfiles/seedJobs.groovy
@@ -1,7 +1,7 @@
 // Job DSL Groovy script that defines the job configuration for the seedJobs Jenkins multibranch pipeline
 // Initial BRANCH_NAME value is passed in through the Jenkins Configuration as Code YAML file
 // Because this is configured as a Multibranch pipeline, BRANCH_NAME can be used in any other Job DSL jobs
-String BRANCH_NAME = "setup-hashicorp-vault" // Prevents getProperty script approval requirement
+String BRANCH_NAME = "${BRANCH_NAME}" // Prevents getProperty script approval requirement
 multibranchPipelineJob('seedJobs')
 {
     branchSources
@@ -68,6 +68,4 @@ multibranchPipelineJob('seedJobs')
             scriptPath('jenkinsfiles/seedJobs')
         }
     }
-
-    disabled()
 }

--- a/jenkinsfiles/seedJobs.groovy
+++ b/jenkinsfiles/seedJobs.groovy
@@ -1,7 +1,7 @@
 // Job DSL Groovy script that defines the job configuration for the seedJobs Jenkins multibranch pipeline
 // Initial BRANCH_NAME value is passed in through the Jenkins Configuration as Code YAML file
 // Because this is configured as a Multibranch pipeline, BRANCH_NAME can be used in any other Job DSL jobs
-String BRANCH_NAME = "${BRANCH_NAME}" // Prevents getProperty script approval requirement
+String BRANCH_NAME = "setup-hashicorp-vault" // Prevents getProperty script approval requirement
 multibranchPipelineJob('seedJobs')
 {
     branchSources
@@ -68,4 +68,6 @@ multibranchPipelineJob('seedJobs')
             scriptPath('jenkinsfiles/seedJobs')
         }
     }
+
+    disabled()
 }

--- a/jenkinsfiles/seedJobs.groovy
+++ b/jenkinsfiles/seedJobs.groovy
@@ -1,4 +1,4 @@
-// Job DSL Groovy script that defines the job configuration for the seedJobs Jenkins pipeline
+// Job DSL Groovy script that defines the job configuration for the seedJobs Jenkins multibranch pipeline
 // Initial BRANCH_NAME value is passed in through the Jenkins Configuration as Code YAML file
 // Because this is configured as a Multibranch pipeline, BRANCH_NAME can be used in any other Job DSL jobs
 String BRANCH_NAME = "${BRANCH_NAME}" // Prevents getProperty script approval requirement

--- a/jenkinsfiles/vaultTest
+++ b/jenkinsfiles/vaultTest
@@ -1,0 +1,37 @@
+#!/usr/bin/env groovy
+
+// Jenkinsfile that defines a declarative Jenkins pipeline used to test Hashicorp Vault plugin
+pipeline
+{
+    agent any
+
+    stages
+    {
+        stage('Getting Secret from Vault')
+        {
+            environment
+            {
+                SCRIPT_PATH = 'scripts/writefile.py'
+                FILE_NAME   = 'secret.txt'
+            }
+
+            steps
+            {
+                checkout(
+                    scmGit(
+                        branches: [[name: BRANCH_NAME]],
+                        extensions: [[$class: 'SparseCheckoutPaths', sparseCheckoutPaths: [[path: SCRIPT_PATH]]]],
+                        userRemoteConfigs: [[url: 'https://github.com/Minreaux/jenkins-test']]
+                    )
+                )
+
+                withCredentials([vaultString(credentialsId: 'vault-secret-text', variable: 'MYSECRET')])
+                {
+                    pwsh("py ${SCRIPT_PATH} ${WORKSPACE}/${FILE_NAME} \$env:MYSECRET")
+                }
+
+                archiveArtifacts(artifacts: FILE_NAME)
+            }
+        }
+    }
+}

--- a/jenkinsfiles/vaultTest
+++ b/jenkinsfiles/vaultTest
@@ -5,6 +5,12 @@ pipeline
 {
     agent any
 
+    options
+    {
+        // Keep only 1 build artifact
+        buildDiscarder(logRotator(artifactNumToKeepStr: '1'))
+    }
+
     stages
     {
         stage('Getting Secret from Vault')

--- a/jenkinsfiles/vaultTest.groovy
+++ b/jenkinsfiles/vaultTest.groovy
@@ -1,0 +1,31 @@
+// Job DSL Groovy script that defines the job configuration for the vaultTest Jenkins multibranch pipeline
+multibranchPipelineJob('vaultTest')
+{
+    branchSources
+    {
+        git
+        {
+            id = 'jenkins-test'
+            remote('https://github.com/Minreaux/jenkins-test.git')
+        }
+    }
+
+    factory
+    {
+        workflowBranchProjectFactory
+        {
+            scriptPath('jenkinsfiles/vaultTest')
+        }
+    }
+
+    orphanedItemStrategy
+    {
+        defaultOrphanedItemStrategy
+        {
+            abortBuilds(true)
+            daysToKeepStr('')
+            numToKeepStr('')
+            pruneDeadBranches(true)
+        }
+    }
+}

--- a/scripts/writeFile.py
+++ b/scripts/writeFile.py
@@ -1,0 +1,11 @@
+import argparse
+import os
+
+parser = argparse.ArgumentParser("writeFile")
+parser.add_argument("path", help="The path of the file to be created or written to", type=str)
+parser.add_argument("text", help="The text to write to the file", type=str)
+args = parser.parse_args()
+
+os.makedirs(os.path.dirname(args.path), exist_ok=True)
+with open(args.path, "w") as file:
+    file.write(args.text)


### PR DESCRIPTION
- Add Hashicorp Vault Plugin to Plugin Installation Manager Tool plugins list
- Setup Hashicorp Vault server in JCasC YAML
- Add vault-jenkins-role credential in JCasC YAML
- Add vault-secret-text credential in JCasC YAML
- Modify Jenkins credentials to only allow Vault-based credential types
- Disable User credential provider
- Add vaultTest pipeline and job-dsl used to test the Vault credential
- Add writeFile Python script
- Update ServiceUser role permissions to include Job/Configure, which is necessary for accessing credentials
- Add initial "seedJobs" pipeline disable to JCasC jobs YAML because it does not work on first boot
- Update READMEs