### PR TITLE
Remove labelAtoms from system JCasC YAML

### DIFF
--- a/configs/casc/system.yaml
+++ b/configs/casc/system.yaml
@@ -5,10 +5,6 @@ jenkins:
   disabledAdministrativeMonitors:
   - "hudson.util.DoubleLaunchChecker"
 
-  # Labels
-  labelAtoms:
-  - name: "built-in"
-
   mode: NORMAL
 
   noUsageStatistics: true


### PR DESCRIPTION
Labels should only be controlled through 1 place and that place should be the nodes JCasC YAML 'labelString' key-value pairs; labelAtoms will auto-modify depending on what labels are defined in nodes YAML