### PR TITLE
Add Job/Build perm to ServiceUser role

### DIFF
--- a/configs/casc/roles.yaml
+++ b/configs/casc/roles.yaml
@@ -44,6 +44,7 @@ jenkins:
           pattern: ".*"
           permissions:
           - "Agent/Build"
+          - "Job/Build"
           - "Job/Configure"
           - "Job/Create"
           - "Job/Delete"


### PR DESCRIPTION
Cannot use build step with service user unless it has Job/Build capabilities